### PR TITLE
Set Doclet Java version to 1.5

### DIFF
--- a/src/main/java/br/com/diogoko/doclet/FreeMarkerDoclet.java
+++ b/src/main/java/br/com/diogoko/doclet/FreeMarkerDoclet.java
@@ -16,9 +16,9 @@ public class FreeMarkerDoclet {
 
     private static TemplateOption template = null;
 
-	public static LanguageVersion languageVersion() {
-		return LanguageVersion.JAVA_1_5;
-	}
+    public static LanguageVersion languageVersion() {
+        return LanguageVersion.JAVA_1_5;
+    }
     
     public static boolean start(RootDoc root) {
         try {

--- a/src/main/java/br/com/diogoko/doclet/FreeMarkerDoclet.java
+++ b/src/main/java/br/com/diogoko/doclet/FreeMarkerDoclet.java
@@ -1,6 +1,7 @@
 package br.com.diogoko.doclet;
 
 import com.sun.javadoc.DocErrorReporter;
+import com.sun.javadoc.LanguageVersion;
 import com.sun.javadoc.RootDoc;
 import freemarker.template.Configuration;
 import freemarker.template.Template;
@@ -15,6 +16,10 @@ public class FreeMarkerDoclet {
 
     private static TemplateOption template = null;
 
+	public static LanguageVersion languageVersion() {
+		return LanguageVersion.JAVA_1_5;
+	}
+    
     public static boolean start(RootDoc root) {
         try {
             Configuration cfg = createConfiguration();


### PR DESCRIPTION
Setting Java version to 1.5 makes generic parameters available in templates 